### PR TITLE
Replace PrintNannyConfig with static lifetime (read config state on request)

### DIFF
--- a/dash/src/debug.rs
+++ b/dash/src/debug.rs
@@ -1,13 +1,17 @@
-use crate::response::Response;
+use crate::auth::PrintNannyConfigFile;
+use crate::response::{FlashResponse, Response};
 use printnanny_services::config::PrintNannyConfig;
 use rocket::serde::json::Json;
 use rocket::State;
+use rocket_dyn_templates::Template;
 
 #[get("/")]
-fn get_config(config: &State<PrintNannyConfig>) -> Response {
+fn get_config(
+    config_file: &State<PrintNannyConfigFile>,
+) -> Result<Response, FlashResponse<Template>> {
+    let config = PrintNannyConfig::new(config_file.0.as_deref())?;
     info!("Rendering config {:?}", config);
-    let c = config.inner().clone();
-    Response::PrintNannyConfig(Json(c))
+    Ok(Response::PrintNannyConfig(Json(config)))
 }
 
 pub fn routes() -> Vec<rocket::Route> {

--- a/dash/src/main.rs
+++ b/dash/src/main.rs
@@ -6,7 +6,6 @@ use rocket_dyn_templates::Template;
 use printnanny_dash::auth;
 use printnanny_dash::debug;
 use printnanny_dash::home;
-use printnanny_services::config::PrintNannyConfig;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -23,16 +22,14 @@ async fn main() -> Result<()> {
                 .help("Path to Config.toml (see env/ for examples)"),
         );
     let app_m = app.get_matches();
-    let config = app_m.value_of("config");
-
-    let config = PrintNannyConfig::new(config)?;
-
+    let config_arg = app_m.value_of("config");
+    let config_file = auth::PrintNannyConfigFile(config_arg.map(str::to_string));
     rocket::build()
         .mount("/", home::routes())
         .mount("/debug", debug::routes())
         .mount("/login", auth::routes())
         .attach(Template::fairing())
-        .manage(config)
+        .manage(config_file)
         .launch()
         .await?;
     Ok(())

--- a/dash/src/response.rs
+++ b/dash/src/response.rs
@@ -38,18 +38,18 @@ impl From<serde_json::Error> for FlashResponse<Redirect> {
     }
 }
 
-// impl From<printnanny_services::printnanny_api::ServiceError> for FlashResponse<Redirect> {
-//     fn from(error: printnanny_services::printnanny_api::ServiceError) -> Self {
-//         let msg = format!("{:?}", error);
-//         let mut context = HashMap::new();
-//         context.insert("errors", &msg);
-//         error!("{}", &msg);
-//         Self(Flash::error(Redirect::to("/"), &msg))
-//     }
-// }
-
 impl From<printnanny_services::printnanny_api::ServiceError> for FlashResponse<Template> {
     fn from(error: printnanny_services::printnanny_api::ServiceError) -> Self {
+        let msg = format!("{:?}", error);
+        let mut context = HashMap::new();
+        context.insert("errors", &msg);
+        error!("{}", &msg);
+        Self(Flash::error(Template::render("error", context), &msg))
+    }
+}
+
+impl From<rocket::figment::Error> for FlashResponse<Template> {
+    fn from(error: rocket::figment::Error) -> Self {
         let msg = format!("{:?}", error);
         let mut context = HashMap::new();
         context.insert("errors", &msg);


### PR DESCRIPTION
If PrintNannyConfig is updated, static lifetime requires the program be restarted. Instead, initialize config inside of request/response loop