### PR TITLE
Fix bug in event_name serde

### DIFF
--- a/services/src/remote.rs
+++ b/services/src/remote.rs
@@ -19,7 +19,8 @@ pub fn handle_event(
         true => Command::new(config.ansible.ansible_playbook())
             .arg(format!(
                 "{}.events.{:?}",
-                config.ansible.collection, event_name
+                config.ansible.collection,
+                event_name.to_string()
             ))
             .arg("-e")
             .arg(format!("'{}'", event_json))
@@ -29,7 +30,8 @@ pub fn handle_event(
         false => Command::new(config.ansible.ansible_playbook())
             .arg(format!(
                 "{}.events.{:?}",
-                config.ansible.collection, event_name
+                config.ansible.collection,
+                event_name.to_string()
             ))
             .arg("-e")
             .arg(format!("'{}'", event_json))


### PR DESCRIPTION
The Debug trait results in the enum field's name being serialized. Instead, call the .to_string() method to serialize event_names such as `stream_start` `stream_stop`

```
Feb 21 10:59:51 octonanny-dev printnanny-mqtt[43408]: [2022-02-21T18:59:51Z INFO  printnanny_services::mqtt] Attempting to deserialize event Topic = /devices/2772943110338374/commands, Qos = AtLeastOnce, Retain = false, Pkid = 2, Payload Size = 200 payload b"{\"id\":42,\"event_type\":\"WebRTCEvent\",\"created_dt\":\"2022-02-21T18:59:50.839712Z\",\"source\":\"printnanny_webapp\",\"event_name\":\"stream_start\",\"data\":{},\"polymorphic_ctype\":70,\"user\":1,\"device\":1,\"stream\":1}"
Feb 21 10:59:52 octonanny-dev printnanny-mqtt[43422]: ERROR! the playbook: bitsyai.printnanny.events.Start could not be found
```