### PR TITLE
serialize janus_local config directive as request (id not required)

### DIFF
--- a/services/src/config.rs
+++ b/services/src/config.rs
@@ -127,7 +127,7 @@ pub struct PrintNannyConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<models::User>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub janus_local: Option<models::JanusStream>,
+    pub janus_local: Option<models::JanusStreamRequest>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub janus_cloud: Option<models::JanusStream>,
 }


### PR DESCRIPTION
Fixes the following error in printnanny-events service:
```
Feb 24 15:00:22 octonanny-dev printnanny-events[86060]: Error: missing field `id` for key "default.janus_local" in opt/printnanny/profiles/default/PrintNanny.toml TOML file
```