### PR TITLE
Compatible with cargo-bitbake util

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.22.0-rc.5"
 authors = ["Leigh Johnson <leigh@bitsy.ai>"]
 edition = "2021"
 rust-version = "1.61"
+repository = "https://github.com/bitsy-ai/printnanny-cli.git"
 
 [dependencies]
 printnanny-dash = {path = "../dash", version = "^0.22.0-rc.5"}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ license = "AGPL-3.0-or-later"
 version = "0.22.0-rc.5"
 authors = ["Leigh Johnson <leigh@bitsy.ai>"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.59"
 repository = "https://github.com/bitsy-ai/printnanny-cli.git"
 
 [dependencies]

--- a/dash/Cargo.toml
+++ b/dash/Cargo.toml
@@ -5,7 +5,7 @@ license = "AGPL-3.0-or-later"
 version = "0.22.0-rc.5"
 authors = ["Leigh Johnson <leigh@bitsy.ai>"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.59"
 
 [dependencies]
 printnanny-services = {path = "../services", version = "^0.22.0-rc.5"}

--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -5,7 +5,7 @@ license = "AGPL-3.0-or-later"
 version = "0.22.0-rc.5"
 authors = ["Leigh Johnson <leigh@bitsy.ai>"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.59"
 
 [dependencies]
 printnanny-services = {path = "../services", version = "^0.22.0-rc.5"}

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -5,7 +5,7 @@ license = "AGPL-3.0-or-later"
 version = "0.22.0-rc.5"
 authors = ["Leigh Johnson <leigh@bitsy.ai>"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.59"
 
 [dependencies]
 async-process = "1.3.0"


### PR DESCRIPTION
https://github.com/meta-rust/cargo-bitbake

cargo-bitbake generates a bitbake recipe, so meta-printnanny can build from source instead of downloading pre-compiled binaries (requires release CI/CD job)