### PR TITLE
Fix trailing slash in default paths

### DIFF
--- a/services/src/config.rs
+++ b/services/src/config.rs
@@ -192,8 +192,8 @@ pub struct PrintNannyPaths {
 impl Default for PrintNannyPaths {
     fn default() -> Self {
         // /etc is mounted as an r/w overlay fs
-        let etc: PathBuf = "/etc/printnanny/".into();
-        let confd: PathBuf = "/etc/printnanny/conf.d/".into();
+        let etc: PathBuf = "/etc/printnanny".into();
+        let confd: PathBuf = "/etc/printnanny/conf.d".into();
         let issue_txt: PathBuf = "/boot/issue.txt".into();
         let run: PathBuf = "/var/run/printnanny".into();
         let log: PathBuf = "/var/log/printnanny".into();


### PR DESCRIPTION
Default paths include an extra slash:
```
Jun 16 20:14:22 pn-octo printnanny-license[753]: [2022-06-17T03:14:22Z INFO  printnanny_services::config] Merging config from /etc/printnanny/conf.d//*.json
Jun 16 20:14:22 pn-octo printnanny-license[753]: [2022-06-17T03:14:22Z INFO  printnanny_services::config] Merging config from /etc/printnanny/conf.d//*.toml
```