### PR TITLE
Move device setup into check-license command handler

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -52,9 +52,11 @@ impl ConfigAction {
 
 pub async fn handle_check_license(infile: &str) -> Result<(), ServiceError> {
     let mut config: PrintNannyConfig = PrintNannyConfig::new()?;
-    let api_service = ApiService::new(config.clone())?;
+    let mut api_service = ApiService::new(config.clone())?;
     info!("Reading license from {}", infile);
     config.api = api_service.check_license(infile).await?;
     config.try_save_by_key("api")?;
+    api_service.config = config;
+    api_service.device_setup().await?;
     Ok(())
 }

--- a/dash/src/auth.rs
+++ b/dash/src/auth.rs
@@ -124,9 +124,8 @@ async fn handle_token_validate(
         ..auth_config.api
     };
     auth_config.api = api_config;
-    let updated_config = handle_device_update(auth_config).await?;
-    info!("Success! Config updated: {:?}", updated_config);
-    Ok(updated_config)
+    auth_config.try_save_by_key("api")?;
+    Ok(auth_config)
 }
 
 #[post("/<email>", data = "<form>")]

--- a/services/src/config.rs
+++ b/services/src/config.rs
@@ -377,11 +377,12 @@ impl PrintNannyConfig {
     /// Save FACTORY_RESET field as <field>.toml Figment fragments
     ///
     /// If serialization or fs write fails, prints an error message indicating the failure
-    pub fn try_save_by_key(&self, key: &str) -> Result<(), PrintNannyConfigError> {
+    pub fn try_save_by_key(&self, key: &str) -> Result<PathBuf, PrintNannyConfigError> {
         let filename = format!("{}.toml", key);
         let filename = self.paths.confd.join(filename);
         self.try_save_fragment(key, &filename)?;
-        Ok(())
+        info!("Saved config fragment: {:?}", &filename);
+        Ok(filename)
     }
 
     pub fn try_save_fragment(


### PR DESCRIPTION
Device setup can be slow and will be subject to change/interation as I roll out x509 cert signing + Wireguard. Remove the slow device_setup() method from the 2fa auth path, which is intended to trade a long-lived license key for a short-lived auth token.

https://github.com/bitsy-ai/printnanny-os/issues/19