### PR TITLE
fix serde_json::Value surrounded with extra pair of quotes

### DIFF
--- a/services/src/printnanny_api.rs
+++ b/services/src/printnanny_api.rs
@@ -325,15 +325,21 @@ impl ApiService {
         let os_variant_id = os_release_json
             .get("VARIANT_ID")
             .unwrap_or(&unknown_value)
-            .to_string();
+            .as_str()
+            .unwrap()
+            .into();
         let os_build_id = os_release_json
             .get("BUILD_ID")
             .unwrap_or(&unknown_value)
-            .to_string();
+            .as_str()
+            .unwrap()
+            .into();
         let os_version_id = os_release_json
             .get("VERSION_ID")
             .unwrap_or(&unknown_value)
-            .to_string();
+            .as_str()
+            .unwrap()
+            .into();
 
         let request = models::SystemInfoRequest {
             machine_id,


### PR DESCRIPTION
Fixes extra quotes in `os_` vars, for example `os_build_id: "\"2022-06-18T18:46:49Z\""`
```
Jun 18 21:42:53 pn-octo printnanny-license[749]: [2022-06-19T04:42:53Z INFO  printnanny_services::printnanny_api] device_system_info_update_or_create request SystemInfoRequest { machine_id: "eba1760ea1554696bb6939a9c57c2eef\n", revision: "d03114", model: "Raspberry Pi 4 Model B Rev 1.4", serial: "10000000ec7fb63f", cores: 4, ram: 8189517824, os_version_id: "\"0.1.2\"", os_build_id: "\"2022-06-18T18:46:49Z\"", os_variant_id: "\"printnanny-octoprint\"", os_release_json: Some({"PRETTY_NAME": String("PrintNanny Linux 0.1.2 (Amber)"), "ID": String("printnanny"), "ID_LIKE": String("BitsyLinux"), "YOCTO_CODENAME": String("Kirkstone"), "VARIANT_ID": String("printnanny-octoprint"), "BUG_REPORT_URL": String("https://github.com/bitsy-ai/printnanny-os/issues"), "YOCTO_VERSION": String("4.0.1"), "BUILD_ID": String("2022-06-18T18:46:49Z"), "HOME_URL": String("https://printnanny.ai"), "SDK_VERSION": String("0.1.2"), "VERSION": String("0.1.2 (Amber)"), "NAME": String("PrintNanny Linux"), "VERSION_ID": String("0.1.2"), "VARIANT": String("PrintNanny OctoPrint Edition"), "DISTRO_CODENAME": String("Amber")}), device: 35 }
```

Ref:
https://stackoverflow.com/questions/53378780/deserialization-of-json-reponse-keeps-quotation-marks-in-strings