### PR TITLE
fix runtime error in license_activate

### DIFF
--- a/services/src/printnanny_api.rs
+++ b/services/src/printnanny_api.rs
@@ -362,7 +362,7 @@ impl ApiService {
     pub async fn license_activate(&self) -> Result<models::License, ServiceError> {
         let license_file = File::open(&self.config.paths.license)?;
         let mut req: models::LicenseRequest = serde_json::from_reader(license_file)?;
-        match &self.device {
+        match &self.config.device {
             Some(device) => {
                 req.device = Some(device.id);
                 Ok(())


### PR DESCRIPTION
```
Jun 19 10:08:34 pn-octo printnanny-license[678]: Error: Setup incomplete, failed to read "device" Some("license_activate()")
Jun 19 10:08:34 pn-octo systemd[1]: printnanny-license.service: Main process exited, code=exited, status=1/FAILURE
```