### PR TITLE
Fix fatal error in dash release build

### DIFF
--- a/dash/src/auth.rs
+++ b/dash/src/auth.rs
@@ -152,12 +152,7 @@ async fn handle_token_validate(
     let bearer_access_token = res.token;
     info!("Success! Authenticated and received bearer token");
 
-    let api_config = models::PrintNannyApiConfig {
-        base_path: service.config.api.base_path,
-        bearer_access_token: Some(bearer_access_token),
-        ..auth_config.api
-    };
-    auth_config.api = api_config;
+    auth_config.api.bearer_access_token = Some(bearer_access_token);
     auth_config.try_save_by_key("api")?;
     Ok(auth_config)
 }


### PR DESCRIPTION
```
   Compiling printnanny-dash v0.24.1 (/home/leigh/projects/printnanny-cli/target/package/printnanny-dash-0.24.1)
error[E0308]: mismatched types
   --> src/auth.rs:158:11
    |
158 |         ..auth_config.api
    |           ^^^^^^^^^^^^^^^ expected struct `PrintNannyApiConfig`, found struct `printnanny_api_client::models::print_nanny_api_config::PrintNannyApiConfig`
    |
    = note: perhaps two different versions of crate `printnanny_api_client` are being used?

error[E0308]: mismatched types
   --> src/auth.rs:160:23
    |
160 |     auth_config.api = api_config;
    |     ---------------   ^^^^^^^^^^ expected struct `printnanny_api_client::models::print_nanny_api_config::PrintNannyApiConfig`, found struct `PrintNannyApiConfig`
    |     |
    |     expected due to the type of this binding
    |
    = note: perhaps two different versions of crate `printnanny_api_client` are being used?

For more information about this error, try `rustc --explain E0308`.
error: could not compile `printnanny-dash` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: failed to verify package tarball
make: *** [Makefile:33: patch] Error 103
```