### PR TITLE
Remove git-version from printnanny-gst crate

### DIFF
--- a/gst/Cargo.toml
+++ b/gst/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = { version = "1", features = ["backtrace"] }
 derive_more = "0.99"
 clap = { version = "3", features = ["derive", "cargo", "env", "wrap_help"] }
 env_logger = "0.9"
-git-version = "0.3"
 gst = { package = "gstreamer", version="0.18.8" }
 log = "0.4"
 tokio = { version = "1.19", features = ["macros"] }

--- a/gst/src/cam.rs
+++ b/gst/src/cam.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use clap::{crate_authors, Arg, ArgMatches, Command};
-use git_version::git_version;
 use gst::prelude::*;
 use log::{error, info};
 
@@ -14,8 +13,6 @@ pub struct PrintNannyCamApp {
     pub video_fps: i32,
     pub video_src: SrcOption,
 }
-
-const GIT_VERSION: &str = git_version!();
 
 impl PrintNannyCamApp {
     pub fn new(args: &ArgMatches) -> Self {
@@ -220,7 +217,6 @@ pub fn clap_command() -> Command<'static> {
     let app = Command::new(app_name)
         .author(crate_authors!())
         .about("Encode live video camera stream")
-        .version(GIT_VERSION)
         .arg(
             Arg::new("v")
                 .short('v')


### PR DESCRIPTION
Fixes a release build failure, which I assume is occurring because `git_version!` only inspects the current working dir / parent dir for `.git` folder, but `cam.rs` is in a `bin/` folder.

```
error: git describe failed with status 128: fatal: not a git repository (or any of the parent directories): .git
  --> /home/leigh/.cargo/registry/src/github.com-1ecc6299db9ec823/printnanny-gst-0.24.3/src/cam.rs:18:27
   |
18 | const GIT_VERSION: &str = git_version!();
   |                           ^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `proc_macro_call` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `printnanny-gst` due to previous error
```