### PR TITLE
Implement os issue subcommand

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -4,9 +4,9 @@ use printnanny_services::error::{PrintNannyConfigError, ServiceError};
 use printnanny_services::printnanny_api::ApiService;
 use std::io::{self, Write};
 
-pub struct ConfigAction;
+pub struct ConfigCommand;
 
-impl ConfigAction {
+impl ConfigCommand {
     pub async fn handle(sub_m: &clap::ArgMatches) -> Result<(), ServiceError> {
         let config: PrintNannyConfig = PrintNannyConfig::new()?;
         match sub_m.subcommand() {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod config;
+pub mod os;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,7 +18,8 @@ use printnanny_dash::home;
 use printnanny_services::config::ConfigFormat;
 use printnanny_services::janus::{ JanusAdminEndpoint, janus_admin_api_call };
 use printnanny_services::mqtt::{ MQTTWorker };
-use printnanny_cli::config::{ConfigAction};
+use printnanny_cli::config::{ConfigCommand};
+use printnanny_cli::os::{OsCommand};
 use printnanny_gst::cam;
 
 const GIT_VERSION: &str = git_version!();
@@ -147,7 +148,15 @@ async fn main() -> Result<()> {
                 Command::new("subscribe")
                 .about("Subscribe to events from MQTT topic")
             ))
-
+        // os <issue|>
+        .subcommand(Command::new("os")
+            .author(crate_authors!())
+            .about(crate_description!())
+            .version(GIT_VERSION)
+            .about("Interact with PrintNanny OS")
+            .arg(Arg::new("issue")
+                .help("Show contents of /etc/issue")))
+        // remote <args>
         .subcommand(Command::new("remote")
             .author(crate_authors!())
             .about(crate_description!())
@@ -221,7 +230,10 @@ async fn main() -> Result<()> {
             }
         },
         Some(("config", subm)) => {
-            ConfigAction::handle(subm).await?;
+            ConfigCommand::handle(subm).await?;
+        },
+        Some(("os", subm)) => {
+            OsCommand::handle(subm)?;
         },
         Some(("janus-admin", sub_m)) => {
             let endpoint: JanusAdminEndpoint = sub_m.value_of_t("endpoint").unwrap_or_else(|e| e.exit());

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -153,9 +153,12 @@ async fn main() -> Result<()> {
             .author(crate_authors!())
             .about(crate_description!())
             .version(GIT_VERSION)
-            .about("Interact with PrintNanny OS")
-            .arg(Arg::new("issue")
-                .help("Show contents of /etc/issue")))
+            .subcommand_required(true)
+            .subcommand(
+                Command::new("issue")
+                .about("Show contents of /etc/issue")
+            )
+            .about("Interact with PrintNanny OS"))
         // remote <args>
         .subcommand(Command::new("remote")
             .author(crate_authors!())

--- a/cli/src/os.rs
+++ b/cli/src/os.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Result};
 use log::error;
 use printnanny_services::config::PrintNannyConfig;
-use printnanny_services::error::ServiceError;
 use std::fs;
 
 pub struct OsCommand;

--- a/cli/src/os.rs
+++ b/cli/src/os.rs
@@ -1,0 +1,29 @@
+use log::error;
+use printnanny_services::config::PrintNannyConfig;
+use printnanny_services::error::ServiceError;
+use std::fs;
+
+pub struct OsCommand;
+
+impl OsCommand {
+    pub fn handle(_sub_m: &clap::ArgMatches) -> Result<(), ServiceError> {
+        let config = PrintNannyConfig::new()?;
+        let result = fs::read_to_string(&config.paths.issue_txt);
+        let output = match result {
+            Ok(content) => content,
+            Err(e) => {
+                let msg = format!(
+                    "Error reading file={:?} error={:?}",
+                    &config.paths.issue_txt, e
+                );
+                error!(
+                    "Error reading file={:?} error={:?}",
+                    &config.paths.issue_txt, e
+                );
+                msg
+            }
+        };
+        print!("{}", output);
+        Ok(())
+    }
+}

--- a/cli/src/os.rs
+++ b/cli/src/os.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Result};
 use log::error;
 use printnanny_services::config::PrintNannyConfig;
 use printnanny_services::error::ServiceError;
@@ -5,25 +6,32 @@ use std::fs;
 
 pub struct OsCommand;
 
+fn handle_issue() -> Result<()> {
+    let config = PrintNannyConfig::new()?;
+    let result = fs::read_to_string(&config.paths.issue_txt);
+    let output = match result {
+        Ok(content) => content,
+        Err(e) => {
+            let msg = format!(
+                "Error reading file={:?} error={:?}",
+                &config.paths.issue_txt, e
+            );
+            error!(
+                "Error reading file={:?} error={:?}",
+                &config.paths.issue_txt, e
+            );
+            msg
+        }
+    };
+    print!("{}", output);
+    Ok(())
+}
+
 impl OsCommand {
-    pub fn handle(_sub_m: &clap::ArgMatches) -> Result<(), ServiceError> {
-        let config = PrintNannyConfig::new()?;
-        let result = fs::read_to_string(&config.paths.issue_txt);
-        let output = match result {
-            Ok(content) => content,
-            Err(e) => {
-                let msg = format!(
-                    "Error reading file={:?} error={:?}",
-                    &config.paths.issue_txt, e
-                );
-                error!(
-                    "Error reading file={:?} error={:?}",
-                    &config.paths.issue_txt, e
-                );
-                msg
-            }
-        };
-        print!("{}", output);
-        Ok(())
+    pub fn handle(sub_m: &clap::ArgMatches) -> Result<()> {
+        match sub_m.subcommand() {
+            Some(("issue", _args)) => handle_issue(),
+            _ => Err(anyhow!("Unhandled subcommand")),
+        }
     }
 }


### PR DESCRIPTION
```
printnanny-cli-os printnanny-cli-v0.24.4-2-g65de10d
Leigh Johnson <leigh@bitsy.ai>
Interact with PrintNanny OS

USAGE:
    printnanny-cli os <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    help     Print this message or the help of the given subcommand(s)
    issue    Show contents of /etc/issue
```
closes https://github.com/bitsy-ai/printnanny-os/issues/48