### PR TITLE
if PrintNannyConfig::FileExists err raised, warn in printnanny config init command instead of throwing error

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -64,7 +64,7 @@ impl ConfigCommand {
                 info!("PrintNannyConfig.paths {:?}", config.paths);
                 config.paths.try_init_dirs()?;
                 match config.paths.unpack_seed(force) {
-                    Ok(r) => Ok(r),
+                    Ok(r) => Ok(()),
                     Err(e) => match e {
                         PrintNannyConfigError::FileExists { .. } => {
                             warn!("{}", e);
@@ -72,10 +72,9 @@ impl ConfigCommand {
                         }
                         _ => Err(e),
                     },
-                    Err(e) => Err(e),
                 }?;
                 match config.paths.unpack_seed(force) {
-                    Ok(r) => Ok(r),
+                    Ok(r) => Ok(()),
                     Err(e) => match e {
                         PrintNannyConfigError::FileExists { .. } => {
                             warn!("{}", e);

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,6 +1,6 @@
 use log::info;
 use printnanny_services::config::{ConfigFormat, PrintNannyConfig};
-use printnanny_services::error::ServiceError;
+use printnanny_services::error::{PrintNannyConfigERror, ServiceError};
 use printnanny_services::printnanny_api::ApiService;
 use std::io::{self, Write};
 
@@ -63,8 +63,22 @@ impl ConfigCommand {
                 let force = args.is_present("force");
                 info!("PrintNannyConfig.paths {:?}", config.paths);
                 config.paths.try_init_dirs()?;
-                config.paths.unpack_seed(force)?;
-                config.paths.try_copy_seed(force)?;
+                match config.paths.unpack_seed(force) {
+                    Ok(r) => Ok(r),
+                    Err(PrintNannyConfig::FileExists(e)) => {
+                        warn!(e);
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                }?;
+                match config.paths.unpack_seed(force) {
+                    Ok(r) => Ok(r),
+                    Err(PrintNannyConfig::FileExists(e)) => {
+                        warn!(e);
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                }
             }
             _ => panic!("Expected generate-keys|get|init|generate-keys subcommand"),
         };

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,6 +1,6 @@
 use log::info;
 use printnanny_services::config::{ConfigFormat, PrintNannyConfig};
-use printnanny_services::error::{PrintNannyConfigERror, ServiceError};
+use printnanny_services::error::{PrintNannyConfigERror, PrintNannyConfigError, ServiceError};
 use printnanny_services::printnanny_api::ApiService;
 use std::io::{self, Write};
 
@@ -65,7 +65,7 @@ impl ConfigCommand {
                 config.paths.try_init_dirs()?;
                 match config.paths.unpack_seed(force) {
                     Ok(r) => Ok(r),
-                    Err(PrintNannyConfig::FileExists(e)) => {
+                    Err(PrintNannyConfigError::FileExists(e)) => {
                         warn!(e);
                         Ok(())
                     }
@@ -73,7 +73,7 @@ impl ConfigCommand {
                 }?;
                 match config.paths.unpack_seed(force) {
                     Ok(r) => Ok(r),
-                    Err(PrintNannyConfig::FileExists(e)) => {
+                    Err(PrintNannyConfigError::FileExists(e)) => {
                         warn!(e);
                         Ok(())
                     }

--- a/services/src/paths.rs
+++ b/services/src/paths.rs
@@ -175,8 +175,8 @@ impl PrintNannyPaths {
             ("nats.creds".to_string(), self.creds().join("nats.creds")),
         ];
 
-        let results = for (filename, dest) in results.iter() {
-            // if target file already fails and --force flag not passed, log a warning and return an error after loop is finished
+        for (filename, dest) in results.iter() {
+            // if target file already fails and --force flag not passed
             if dest.exists() && force == false {
                 return Err(PrintNannyConfigError::FileExists {
                     path: dest.to_path_buf(),
@@ -210,7 +210,7 @@ impl PrintNannyPaths {
                 }),
             }?;
             info!("Wrote seed file {:?}", dest);
-        };
+        }
         Ok(results)
     }
 }

--- a/services/src/paths.rs
+++ b/services/src/paths.rs
@@ -1,7 +1,7 @@
 extern crate glob;
 use self::glob::glob;
 use super::os_release::OsRelease;
-use log::info;
+use log::{info, warn};
 use serde;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -175,8 +175,8 @@ impl PrintNannyPaths {
             ("nats.creds".to_string(), self.creds().join("nats.creds")),
         ];
 
-        for (filename, dest) in results.iter() {
-            // if target file already fails and --force flag not passed, bail
+        let results = for (filename, dest) in results.iter() {
+            // if target file already fails and --force flag not passed, log a warning and return an error after loop is finished
             if dest.exists() && force == false {
                 return Err(PrintNannyConfigError::FileExists {
                     path: dest.to_path_buf(),
@@ -210,7 +210,7 @@ impl PrintNannyPaths {
                 }),
             }?;
             info!("Wrote seed file {:?}", dest);
-        }
+        };
         Ok(results)
     }
 }


### PR DESCRIPTION
… is run (init will always run at starup)