### PR TITLE
upgrade async-nats to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7a978fbbf815c3dc2e36be3af06eadd69182c299a71eacfed7529c7c5b0778"
+checksum = "c7f3d93ad98fe0aed0236fd887b5f26b26edd7d40f3f3d2cd0fc5dc23cf1a7c3"
 dependencies = [
  "base64-url",
  "bytes",

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -18,7 +18,7 @@ async-process = "1.4.0"
 bytes = "1.2"
 anyhow = "1"
 clap = { version = "3", features = ["derive", "cargo", "env", "wrap_help"] }
-async-nats = "0.17.0"
+async-nats = "0.18.0"
 env_logger = "0.9"
 futures = "0.3"
 printnanny-services = {path = "../services", version = "^0.25.0"}


### PR DESCRIPTION
pulling in: https://github.com/nats-io/nats.rs/pull/578