### PR TITLE
Fix incorrect subcommand nesting

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,7 +10,8 @@ use git_version::git_version;
 
 
 use printnanny_cli::cam::CameraCommand;
-use printnanny_nats::subscriber::NatsSubscriber;
+use printnanny_nats::cloud_publisher::DEFAULT_NATS_CLOUD_PUBLISHER_APP_NAME;
+use printnanny_nats::subscriber::{ DEFAULT_NATS_EDGE_APP_NAME, NatsSubscriber};
 use printnanny_nats::message_v2::{NatsReply, NatsRequest};
 use printnanny_nats::cloud_worker::DEFAULT_NATS_CLOUD_APP_NAME;
 use printnanny_settings::{SettingsFormat};
@@ -54,7 +55,7 @@ async fn main() -> Result<()> {
                 .default_value("json")
                 .help("Output format")
             )     
-        ))
+        )
 
         // dash
         .subcommand(Command::new("dash")
@@ -191,13 +192,13 @@ async fn main() -> Result<()> {
             ))
 
         // nats-edge-worker
-        .subcommand(NatsSubscriber::<NatsRequest, NatsReply>::clap_command(None))
+        .subcommand(NatsSubscriber::<NatsRequest, NatsReply>::clap_command(Some(DEFAULT_NATS_EDGE_APP_NAME.to_string())))
         // TODO
         // .subcommand(printnanny_nats::subscriber::NatsSubscriber::<NatsRequest, NatsReply>::clap_command(None))
         // nats-cloud-worker
-        .subcommand(printnanny_nats::cloud_worker::NatsCloudWorker::clap_command(None))
+        .subcommand(printnanny_nats::cloud_worker::NatsCloudWorker::clap_command(Some(DEFAULT_NATS_CLOUD_APP_NAME.to_string())))
         // nats-cloud-publisher
-        .subcommand(printnanny_nats::cloud_publisher::CloudEventPublisher::clap_command())
+        .subcommand(printnanny_nats::cloud_publisher::CloudEventPublisher::clap_command(Some(DEFAULT_NATS_CLOUD_PUBLISHER_APP_NAME.to_string())))
         // os <issue|motd>
         .subcommand(Command::new("os")
             .author(crate_authors!())
@@ -225,7 +226,7 @@ async fn main() -> Result<()> {
                 )
             )
             .about("Interact with PrintNanny OS")
-        );
+        ));
     
     
     let app_m = app.get_matches();

--- a/nats/src/bin/nats-cloud-publisher.rs
+++ b/nats/src/bin/nats-cloud-publisher.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
-use printnanny_nats::cloud_publisher:: CloudEventPublisher;
+use printnanny_nats::cloud_publisher::CloudEventPublisher;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
-    let app =  CloudEventPublisher::clap_command();
-    let publisher =  CloudEventPublisher::new(&app.get_matches())?;
+    let app = CloudEventPublisher::clap_command(None);
+    let publisher = CloudEventPublisher::new(&app.get_matches())?;
     publisher.run().await?;
     Ok(())
 }

--- a/nats/src/cloud_publisher.rs
+++ b/nats/src/cloud_publisher.rs
@@ -23,6 +23,8 @@ use printnanny_services::error;
 
 use crate::subjects;
 
+pub const DEFAULT_NATS_CLOUD_PUBLISHER_APP_NAME: &str = "nats-cloud-publisher";
+
 #[derive(Debug, Clone)]
 pub struct CloudEventPublisher {
     args: ArgMatches,
@@ -49,8 +51,10 @@ impl CloudEventPublisher {
             state,
         })
     }
-    pub fn clap_command() -> Command<'static> {
-        let app_name = "nats-cloud-publisher";
+    pub fn clap_command(app_name: Option<String>) -> Command<'static> {
+        let app_name =
+            app_name.unwrap_or_else(|| DEFAULT_NATS_CLOUD_PUBLISHER_APP_NAME.to_string());
+
         let app = Command::new(app_name)
             .author(crate_authors!())
             .about("Issue command via NATs")


### PR DESCRIPTION
Fixes `os motd` running subscriber command:
```
pn-v0-5:/home/pi# /usr/bin/printnanny os motd       
[2022-12-13T17:32:24Z WARN  printnanny_nats::subscriber] Subscribing to subect pi.pn-v0-5.> with nats client Some(Client { sender: Sender { chan: Tx { inner: Chan { tx: Tx { block_tail: 0x55987a0bf0, tail_position: 1 }, semaphore: Semaphore { semaphore: Semaphore { permits: 127 }, bound: 128 }, rx_waker: AtomicWaker, tx_count: 3, rx_fields: "..." } } }, next_subscription_id: 0, subscription_capacity: 1024 })
[2022-12-13T17:32:24Z WARN  printnanny_nats::subscriber] Listening on nats://localhost:4223 where subject=pi.pn-v0-5.>
```