### PR TITLE
Revert upgrade to rust 1.64 (back to 1.63)

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ license = "AGPL-3.0-or-later"
 version = "0.31.0"
 authors = ["Leigh Johnson <leigh@printnanny.ai>"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.63"
 repository = "https://github.com/bitsy-ai/printnanny-rs.git"
 
 [dependencies]

--- a/dbus/Cargo.toml
+++ b/dbus/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Leigh Johnson <leigh@printnanny.ai>"]
 description = "D-bus APIs used by PrintNanny.ai"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/bitsy-ai/printnanny-rs.git"
-rust-version = "1.64"
+rust-version = "1.63"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/gst-plugin/Cargo.toml
+++ b/gst-plugin/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.4.0"
 edition = "2021"
 authors = ["Leigh Johnson <leigh@printnanny.ai>"]
 license-file = "LICENSE"
-rust-version = "1.64"
+rust-version = "1.63"
 repository = "https://github.com/bitsy-ai/printnanny-gst-plugin-rs/"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -5,7 +5,7 @@ license = "AGPL-3.0-or-later"
 version = "0.31.0"
 authors = ["Leigh Johnson <leigh@printnanny.ai>"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.63"
 repository = "https://github.com/bitsy-ai/printnanny-rs.git"
 
 [[bin]]

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -5,7 +5,7 @@ license = "AGPL-3.0-or-later"
 version = "0.31.0"
 authors = ["Leigh Johnson <leigh@printnanny.ai>"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.63"
 
 [dependencies]
 async-process = "1.3"

--- a/settings/Cargo.toml
+++ b/settings/Cargo.toml
@@ -7,7 +7,7 @@ license = "AGPL-3.0-or-later"
 description = "Utilities for interacting with PrintNanny settings"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-rust-version = "1.64"
+rust-version = "1.63"
 
 [dependencies]
 printnanny-api-client = "0.113.0"


### PR DESCRIPTION
1.64 is not available in poky landale branch
