### PR TITLE
Debugging choppiness in video stream

### DIFF
--- a/gst-plugin/src/bin/printnanny-gst-pipeline.rs
+++ b/gst-plugin/src/bin/printnanny-gst-pipeline.rs
@@ -423,6 +423,10 @@ impl PipelineApp {
             .property("option1", "printnanny_bb_dataframe_decoder")
             .build()?;
 
+        let df_agg_q = gst::ElementFactory::make("queue")
+            .name("queue__df_agg")
+            .build()?;
+
         let dataframe_agg = gst::ElementFactory::make("dataframe_agg")
             .name("dataframe_agg__df")
             .property("filter-threshold", nms_threshold as f32 / 100_f32)
@@ -436,6 +440,7 @@ impl PipelineApp {
         let df_elements = &[
             &df_decoder_q,
             &dataframe_decoder,
+            &df_agg_q,
             &dataframe_agg,
             &nats_sink,
         ];

--- a/gst-plugin/src/bin/printnanny-gst-pipeline.rs
+++ b/gst-plugin/src/bin/printnanny-gst-pipeline.rs
@@ -265,6 +265,17 @@ impl PipelineApp {
             .property_from_str("leaky", "2")
             .build()?;
 
+        // set a variable capsfilter
+        let leaky_capsfilter = gst::ElementFactory::make("capsfilter")
+            .name("capsfilter__leaky")
+            .build()?;
+        leaky_capsfilter.set_property(
+            "caps",
+            gst::Caps::builder("video/x-raw")
+                .field("framerate", "1/1")
+                .build(),
+        );
+
         let tensor_vconverter = gst::ElementFactory::make("videoconvert")
             .name("videoconvert__tflite_dim")
             .build()?;

--- a/gst-plugin/src/bin/printnanny-gst-pipeline.rs
+++ b/gst-plugin/src/bin/printnanny-gst-pipeline.rs
@@ -350,9 +350,6 @@ impl PipelineApp {
         let box_videoconverter = gst::ElementFactory::make("videoconvert")
             .name("videoconvert__boxes")
             .build()?;
-        let box_videorate = gst::ElementFactory::make("videorate")
-            .name("videorate__boxes")
-            .build()?;
         let raw_box_capsfilter = gst::ElementFactory::make("capsfilter")
             .name("capsfilter__boxes")
             .build()?;
@@ -413,7 +410,6 @@ impl PipelineApp {
             &box_decoder_q,
             &box_decoder,
             &box_videoconverter,
-            &box_videorate,
             &raw_box_capsfilter,
             &box_h264encoder,
             &box_h264_capsfilter,

--- a/gst-plugin/src/bin/printnanny-gst-pipeline.rs
+++ b/gst-plugin/src/bin/printnanny-gst-pipeline.rs
@@ -892,8 +892,11 @@ async fn main() {
             let settings = PrintNannySettings::from_toml(PathBuf::from(settings_file))
                 .expect("Failed to extract settings");
             info!("Pipeline settings: {:?}", settings);
+            let tmp_dir = PathBuf::from(args.value_of("tmp_dir").unwrap_or("/tmp"));
+
             PipelineApp {
                 settings: settings.camera,
+                tmp_dir,
             }
         }
         None => PipelineApp::from(&args),

--- a/gst-plugin/src/bin/printnanny-gst-pipeline.rs
+++ b/gst-plugin/src/bin/printnanny-gst-pipeline.rs
@@ -78,7 +78,6 @@ impl PipelineApp {
         let nats_server_uri = self.settings.detection.nats_server_uri.clone();
 
         let pipeline = gst::Pipeline::new(Some(&pipeline_name));
-        let h264_queue = gst::ElementFactory::make("queue").name("h264_q").build()?;
 
         let video_tee = gst::ElementFactory::make("tee")
             .name("tee__inputvideo")
@@ -191,7 +190,7 @@ impl PipelineApp {
                         // &invideoscaler,
                         // &raw_video_capsfilter,
                         &video_tee,
-                        &h264_queue,
+                        &rtp_queue,
                         &invideoconverter,
                         &encoder,
                         &video_h264_capsfilter,
@@ -233,11 +232,10 @@ impl PipelineApp {
                         // &invideoscaler,
                         // &raw_video_capsfilter,
                         &video_tee,
-                        &h264_queue,
+                        &rtp_queue,
                         &invideoconverter,
                         &encoder,
                         &video_h264_capsfilter,
-                        &rtp_queue,
                         &video_payloader,
                         &video_udp_sink,
                     ];

--- a/gst-plugin/src/bin/printnanny-gst-pipeline.rs
+++ b/gst-plugin/src/bin/printnanny-gst-pipeline.rs
@@ -338,6 +338,7 @@ impl PipelineApp {
         let box_decoder_q = gst::ElementFactory::make("queue")
             .name("queue__box_decoder")
             .build()?;
+
         let box_decoder = gst::ElementFactory::make("tensor_decoder")
             .name("tensor__decoder_boxes")
             .property_from_str("mode", "bounding_boxes")
@@ -409,12 +410,12 @@ impl PipelineApp {
         let box_overlay_elements = &[
             &box_decoder_q,
             &box_decoder,
+            &box_udpsink_q2,
             &box_videoconverter,
             &raw_box_capsfilter,
             &box_h264encoder,
             &box_h264_capsfilter,
             &boxes_payloader,
-            &box_udpsink_q2,
             &box_udpsink,
         ];
 


### PR DESCRIPTION
ref: https://github.com/bitsy-ai/printnanny-os/issues/173

* Use queue2 elements for network io, buffer to /tmp files
* Move `DataframeAgg` element into separate thread
* Remove frame up-sampling for bounding box pipeline segments
