### PR TITLE
Fix: user field should be read-only when updating crash report by id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,9 +3182,9 @@ checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 
 [[package]]
 name = "printnanny-api-client"
-version = "0.124.0"
+version = "0.124.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cc16c4673e6625c5686c89d86c077e1980a7bfe313f2f881c14297619b52b0"
+checksum = "048d03b70108cfd7d3983d2f3fb6baf09c11f491665f4e767f37a4bc9c1f7e17"
 dependencies = [
  "bytes",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/bitsy-ai/printnanny-rs.git"
 printnanny-dbus = { path = "../dbus", version = "^0.4"}
 printnanny-services = {path = "../services", version = "^0.32.0"}
 printnanny-nats = {path = "../nats", version = "^0.32.0"}
-printnanny-api-client = "0.124.0"
+printnanny-api-client = "0.124.1"
 printnanny-settings = { path = "../settings", version = "^0.4"}
 
 figment = { version = "0.10", features = ["env", "json", "toml"] }

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -39,7 +39,7 @@ futures-util = "0.3.25"        # Common utilities and extension traits for the f
 git-version = "0.3"
 log = "0.4"
 nix = {version = "0.26.1", features = ["net"]}
-printnanny-api-client = "0.124.0"
+printnanny-api-client = "0.124.1"
 printnanny-dbus = { path = "../dbus", version = "^0.4"}
 printnanny-settings = { path = "../settings", version = "^0.4"}
 printnanny-services = {path = "../services", version = "^0.32.0"}

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -23,7 +23,7 @@ jsonwebtoken = "7"
 lazy_static = "1"            # A macro for declaring lazily evaluated statics in Rust.
 log = "0.4"
 parking_lot = "0.12.1"                  # More compact and efficient implementations of the standard synchronization primitives.
-printnanny-api-client = "0.124.0"
+printnanny-api-client = "0.124.1"
 printnanny-dbus = { path = "../dbus", version = "^0.4"}
 printnanny-settings = { path = "../settings", version = "^0.4"}
 procfs = "0.12"

--- a/services/src/printnanny_api.rs
+++ b/services/src/printnanny_api.rs
@@ -160,7 +160,6 @@ impl ApiService {
             posthog_session,
             status,
             None,
-            user,
             pi,
         )
         .await?;
@@ -185,8 +184,6 @@ impl ApiService {
 
         let pi = self.pi.as_ref().map(|pi| pi.id);
 
-        let user = self.user.as_ref().map(|user| user.id);
-
         let result = crash_reports_api::crash_reports_partial_update(
             &self.reqwest_config(),
             id,
@@ -200,7 +197,6 @@ impl ApiService {
             None,
             None,
             None,
-            user,
             pi,
         )
         .await?;

--- a/settings/Cargo.toml
+++ b/settings/Cargo.toml
@@ -10,7 +10,7 @@ description = "Utilities for interacting with PrintNanny settings"
 rust-version = "1.63"
 
 [dependencies]
-printnanny-api-client = "0.124.0"
+printnanny-api-client = "0.124.1"
 async-trait = "0.1"
 bytes = "1"
 gst = { package = "gstreamer", features = ["v1_20"], version = "0.19" }


### PR DESCRIPTION
closes: https://github.com/bitsy-ai/printnanny-os/issues/202