### PR TITLE
move PrintNannyPipelineFactory into a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,6 +3292,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "printnanny-gst-pipelines"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "gst-client",
+ "log",
+ "printnanny-settings",
+]
+
+[[package]]
 name = "printnanny-gst-plugin"
 version = "0.5.0"
 dependencies = [
@@ -3303,7 +3313,6 @@ dependencies = [
  "env_logger",
  "git-version",
  "glob",
- "gst-client",
  "gst-plugin-version-helper",
  "gstreamer",
  "gstreamer-app",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3256,7 +3256,7 @@ dependencies = [
  "log",
  "printnanny-api-client",
  "printnanny-dbus",
- "printnanny-gst-plugin",
+ "printnanny-gst-pipelines",
  "printnanny-nats",
  "printnanny-services",
  "printnanny-settings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "db",
     "dbus",
     "gst-client-rs",
+    "gst-pipelines",
     "gst-plugin",
     "settings",
     "services",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ printnanny-services = {path = "../services", version = "^0.32.0"}
 printnanny-nats = {path = "../nats", version = "^0.32.0"}
 printnanny-api-client = "0.124.1"
 printnanny-settings = { path = "../settings", version = "^0.4"}
-printnanny-gst-pipelines = { path = "../gst-pipelines", version = "^0.5", package="printnanny-gst-pipelines"}
+printnanny-gst-pipelines = { path = "../gst-pipelines", version = "^0.1", package="printnanny-gst-pipelines"}
 
 figment = { version = "0.10", features = ["env", "json", "toml"] }
 anyhow = { version = "1", features = ["backtrace"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ printnanny-services = {path = "../services", version = "^0.32.0"}
 printnanny-nats = {path = "../nats", version = "^0.32.0"}
 printnanny-api-client = "0.124.1"
 printnanny-settings = { path = "../settings", version = "^0.4"}
-printnanny-gst-plugin = { path = "../gst-plugin", version = "^0.5", package="printnanny-gst-plugin"}
+printnanny-gst-pipelines = { path = "../gst-pipelines", version = "^0.5", package="printnanny-gst-pipelines"}
 
 figment = { version = "0.10", features = ["env", "json", "toml"] }
 anyhow = { version = "1", features = ["backtrace"] }

--- a/cli/src/cam.rs
+++ b/cli/src/cam.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use anyhow::{Ok, Result};
 
-use printnanny_gst_plugin::factory::PrintNannyPipelineFactory;
+use printnanny_gst_pipelines::factory::PrintNannyPipelineFactory;
 use printnanny_settings::{cam::CameraVideoSource, SettingsFormat};
 
 pub struct CameraCommand;

--- a/cli/src/gst.rs
+++ b/cli/src/gst.rs
@@ -1,4 +1,0 @@
-use gst_client::GstClient;
-
-let client = GstClient::build("http://0.0.0.0:5000")?;
-let new_pipeline = client.pipeline("new-pipeline").create("playbin")?;

--- a/gst-pipelines/Cargo.toml
+++ b/gst-pipelines/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+description = "PrintNanny Gstreamer Pipelines"
+name = "printnanny-gst-pipelines"
+version = "0.1.0"
+edition = "2021"
+authors = ["Leigh Johnson <leigh@printnanny.ai>"]
+license-file = "../LICENSE"
+rust-version = "1.63"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"                                   # Flexible concrete Error type built on std::error::Error
+gst-client = { path = "../gst-client-rs" }
+printnanny-settings = { package="printnanny-settings", version = "^0.4", path="../settings" }
+log = "0.4"                  # A lightweight logging facade for Rust 

--- a/gst-pipelines/src/factory.rs
+++ b/gst-pipelines/src/factory.rs
@@ -3,16 +3,10 @@ use gst_client::GstClient;
 use log::info;
 
 use printnanny_settings::{
-    cam::CameraVideoSource, cam::VideoSource, printnanny::PrintNannySettings, SettingsFormat,
+    cam::CameraVideoSource, cam::VideoSource, printnanny::PrintNannySettings
 };
 
 use anyhow::Result;
-
-pub fn gst_client_address(args: &clap::ArgMatches) -> String {
-    let address = args.value_of("http-address").unwrap();
-    let port = args.value_of("http-port").unwrap();
-    format!("http://{address}:{port}")
-}
 
 pub struct PrintNannyPipelineFactory {
     pub address: String,

--- a/gst-pipelines/src/lib.rs
+++ b/gst-pipelines/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod factory;

--- a/gst-plugin/Cargo.toml
+++ b/gst-plugin/Cargo.toml
@@ -20,15 +20,13 @@ byte-slice-cast = "1.2"    # Safely cast bytes slices from/to slices of built-in
 clap = { version = "3", features = ["derive", "cargo", "env", "wrap_help"] }
 libc = "0.2"             # Raw FFI bindings to platform libraries like libc.
 env_logger = "0.9.1"              # A logging implementation for `log` which is configured via an environment variable. 
-log = "0.4.17"                  # A lightweight logging facade for Rust 
+log = "0.4"                  # A lightweight logging facade for Rust 
 git-version = "0.3"
 gst = { package = "gstreamer", features = ["v1_20"], version = "0.19" }
 gst-app = { package = "gstreamer-app", features = ["v1_20"], version = "0.19"}
 gst-sys = { package = "gstreamer-sys", features = ["v1_20"], version = "0.19"}
 gst-base = { package = "gstreamer-base", features = ["v1_20"], version = "0.19"}
 gst-video = { package = "gstreamer-video", features = ["v1_20"], version = "0.19"}
-gst-client = { path = "../gst-client-rs" }
-
 printnanny-settings = { package="printnanny-settings", version = "^0.4", path="../settings" }
 once_cell = "1.0"
 thiserror = "1.0"               # derive(Error)

--- a/gst-plugin/src/lib.rs
+++ b/gst-plugin/src/lib.rs
@@ -4,7 +4,6 @@ mod dataframe_filesink;
 mod nats_sink;
 
 pub mod error;
-pub mod factory;
 pub mod ipc;
 pub mod nnstreamer;
 pub mod tensor;

--- a/services/src/printnanny_api.rs
+++ b/services/src/printnanny_api.rs
@@ -145,9 +145,6 @@ impl ApiService {
         let os_release = OsRelease::new()?;
 
         let pi = self.pi.as_ref().map(|pi| pi.id);
-
-        let user = self.user.as_ref().map(|user| user.id);
-
         let result = crash_reports_api::crash_reports_create(
             &self.reqwest_config(),
             description,


### PR DESCRIPTION
So the cli crate doesn't depend on a full gstreamer application stack
