### PR TITLE
fix: NATS subject incorrectly rendered when Raspberry Pi hostname is "printnanny"

### DIFF
--- a/nats/src/message_v2.rs
+++ b/nats/src/message_v2.rs
@@ -43,7 +43,8 @@ pub trait NatsRequestHandler {
     type Reply: Serialize + DeserializeOwned + Clone + Debug;
 
     fn replace_subject_pattern(subject: &str, pattern: &str, replace: &str) -> String {
-        subject.replace(pattern, replace)
+        // replace only first instance of pattern
+        subject.replacen(pattern, replace, 1)
     }
     fn deserialize_payload(subject_pattern: &str, payload: &Bytes) -> Result<Self::Request>;
     async fn handle(&self) -> Result<Self::Reply>;
@@ -80,7 +81,7 @@ pub enum NatsRequest {
     DeviceInfoLoadRequest,
 
     // pi.{pi_id}.settings.*
-    #[serde(rename = "pi.{pi_id}.settings.cloud.auth")]
+    #[serde(rename = "pi.{pi_id}.settings.printnanny.cloud.auth")]
     PrintNannyCloudAuthRequest(PrintNannyCloudAuthRequest),
     #[serde(rename = "pi.{pi_id}.settings.file.load")]
     SettingsFileLoadRequest,
@@ -145,7 +146,7 @@ pub enum NatsReply {
     DeviceInfoLoadReply(DeviceInfoLoadReply),
 
     // pi.{pi_id}.settings.*
-    #[serde(rename = "pi.{pi_id}.settings.cloud.auth")]
+    #[serde(rename = "pi.{pi_id}.settings.printnanny.cloud.auth")]
     PrintNannyCloudAuthReply(PrintNannyCloudAuthReply),
     #[serde(rename = "pi.{pi_id}.settings.printnanny.load")]
     SettingsFileLoadReply(SettingsFileLoadReply),
@@ -1091,7 +1092,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replace_subject_pattern() {
+    fn test_replace_subject_pattern_systemd() {
         let subject = NatsRequest::replace_subject_pattern(
             "pi.localhost.dbus.org.freedesktop.systemd1.Manager.GetUnit",
             "localhost",
@@ -1103,6 +1104,16 @@ mod tests {
         )
     }
 
+    #[test]
+    fn test_replace_subject_pattern_printnanny_hostname() {
+        // "printnanny" is a valid value for {pi_id} but shouldn't be replaced in subsequent patterns
+        let subject = NatsRequest::replace_subject_pattern(
+            "pi.printnanny.settings.printnanny.cloud.auth",
+            "printnanny",
+            "{pi_id}",
+        );
+        assert_eq!(subject, "pi.{pi_id}.settings.printnanny.cloud.auth")
+    }
     #[test(tokio::test)]
     async fn test_device_info_load() {
         let request = NatsRequest::DeviceInfoLoadRequest;

--- a/nats/src/message_v2.rs
+++ b/nats/src/message_v2.rs
@@ -80,7 +80,7 @@ pub enum NatsRequest {
     DeviceInfoLoadRequest,
 
     // pi.{pi_id}.settings.*
-    #[serde(rename = "pi.{pi_id}.settings.printnanny.cloud.auth")]
+    #[serde(rename = "pi.{pi_id}.settings.cloud.auth")]
     PrintNannyCloudAuthRequest(PrintNannyCloudAuthRequest),
     #[serde(rename = "pi.{pi_id}.settings.file.load")]
     SettingsFileLoadRequest,
@@ -145,7 +145,7 @@ pub enum NatsReply {
     DeviceInfoLoadReply(DeviceInfoLoadReply),
 
     // pi.{pi_id}.settings.*
-    #[serde(rename = "pi.{pi_id}.settings.printnanny.cloud.auth")]
+    #[serde(rename = "pi.{pi_id}.settings.cloud.auth")]
     PrintNannyCloudAuthReply(PrintNannyCloudAuthReply),
     #[serde(rename = "pi.{pi_id}.settings.printnanny.load")]
     SettingsFileLoadReply(SettingsFileLoadReply),


### PR DESCRIPTION
Fixes the following error on a Rasberry Pi with hostname `printnanny`:

```
Jan 26 16:21:20 printnanny printnanny-nats[1070]: [2023-01-26T21:21:20Z ERROR printnanny_nats::subscriber] Error deserializing NATS message: NATS message handler not implemented for subject pattern pi.{pi_id}.settings.{pi_id}.cloud.auth
```

This subject pattern should be `pi.{pi_id}.settings.printnanny.cloud.auth` - but `printnanny` is getting replaced multiple times if the hostname is also `printnanny`

https://github.com/bitsy-ai/printnanny-os/issues/225