### PR TITLE
apply interlace caps to jpeg snapshot pipeline

### DIFF
--- a/gst-pipelines/src/factory.rs
+++ b/gst-pipelines/src/factory.rs
@@ -116,8 +116,9 @@ impl PrintNannyPipelineFactory {
         let interpipesrc = Self::to_interpipesrc_name(pipeline_name);
         let listen_to = Self::to_interpipesink_name(listen_to);
         let colorimetry = "bt709";
+        let interlace = "progressive";
 
-        let description = format!("interpipesrc name={interpipesrc} listen-to={listen_to} accept-events=true accept-eos-event=false is-live=true allow-renegotiation=false format=3 leaky-type=1 caps=video/x-raw,width={width},height={height},framerate={framerate_n}/{framerate_d},format={format},colorimetry={colorimetry} \
+        let description = format!("interpipesrc name={interpipesrc} listen-to={listen_to} accept-events=true accept-eos-event=false is-live=true allow-renegotiation=false format=3 leaky-type=1 caps=video/x-raw,width={width},height={height},framerate={framerate_n}/{framerate_d},format={format},colorimetry={colorimetry},interlace={interlace} \
             ! v4l2jpegenc ! multifilesink location={filesink_location} max-files=2",
             width=camera.width,
             height=camera.height,


### PR DESCRIPTION
My USB camera is failing to negotiate a caps value for `interlace`, so let's provide one. :eyes: 

Double-check that IMX sensors are still able to negotiate caps after this change. Ref: https://github.com/bitsy-ai/printnanny-os/issues/219#issuecomment-1407520808
