### PR TITLE
Refresh NATs nkey credentials when running `printnanny cloud sync-models`

### DIFF
--- a/cli/src/cloud_data.rs
+++ b/cli/src/cloud_data.rs
@@ -19,7 +19,9 @@ impl CloudDataCommand {
             Some(("sync-models", _args)) => {
                 let service = ApiService::from(&settings);
                 service.sync().await?;
+                service.refresh_nats_creds().await?;
             }
+
             Some(("sync-video-recordings", args)) => {
                 let id = args.value_of("id");
                 match id {


### PR DESCRIPTION
ref: https://github.com/bitsy-ai/printnanny-os/issues/248